### PR TITLE
fix issue #1264

### DIFF
--- a/egs/wsj/s5/steps/libs/nnet3/xconfig/lstm.py
+++ b/egs/wsj/s5/steps/libs/nnet3/xconfig/lstm.py
@@ -346,7 +346,7 @@ class XconfigLstmpLayer(XconfigLayerBase):
         affine_str = self.config['ng-affine-options']
         pes_str = self.config['ng-per-element-scale-options']
         lstm_dropout_value = self.config['dropout-proportion']
-        lstm_dropout_str = 'dropout-proportion='+str(self.config['dropout-proportion'])
+        lstm_dropout_str = 'dropout-proportion={0}'.format( self.config['dropout-proportion'] )
 
         # Natural gradient per element scale parameters
         # TODO: decide if we want to keep exposing these options
@@ -761,7 +761,6 @@ class XconfigFastLstmpLayer(XconfigLayerBase):
                         'ng-affine-options' : ' max-change=1.5',
                         'zeroing-interval' : 20,
                         'zeroing-threshold' : 15.0
-
                         }
 
     def set_derived_configs(self):


### PR DESCRIPTION
fix issue in #1264
I hope to settle schedule like this ` '0,0@0.20,0.5@0.50,0@0.50,0'` in my way (check and plus one)....
like this `[(612, 0.0), (307.0, 0.0), (306.0, 0.4), (122.4, 0.0), (0, 0.0)]`
And another thing, it will be best if the scripts could give some warning if dropout remains in the combination iters